### PR TITLE
Fix wrong answer arising due to hash collisions

### DIFF
--- a/src/algos/meta/mod.rs
+++ b/src/algos/meta/mod.rs
@@ -106,8 +106,14 @@ where
     let nb_traces = target.len();
     // Check whether the fom
     if let Some(f) = initial_cache.get_from_cv(target, target) {
-        debug!("Formula found in cache");
-        return Some(f);
+        // Due to hash collisions, the formula may not be right; we check that
+        // the formula has the right characteristic vector.
+        if f.eval(traces).accepted_vec() == target {
+            debug!("Formula found in cache");
+            return Some(f);
+        } else {
+            debug!("Hash collision found a wrong formula {f} for target {target:?}; continuing");
+        }
     }
     if nb_traces > 128 {
         split_and_solve_non_overlapping(traces, operators, initial_cache, target, params)


### PR DESCRIPTION
In the current version of the code, some wrong answers are very rarely returned due to hash collisions. Here is an example (where the test comes from this repository: https://github.com/bmouillon/LTL-Benchmarks):

```
> target/release/ltl-rs LTL-Benchmarks/and_patterns/as_2_pn_2_1.trace 8 0 enum 9 0
thread 'main' panicked at src/main.rs:83:9:
assertion `left == right` failed
  left: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, true]
 right: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false]
```

More precisely, the problem comes from function [`get_from_cv()`](https://github.com/SynthesisLab/Bolt/blob/main/src/algos/meta/cache.rs#L66), which looks for a formula with some specified satisfiability vector based on the hash of the vector. In the above example, the satisfiability vector of a formula that is not a solution has the same hash as the "valid" satisfiability vector.

To fix it, when we recover a formula using `get_from_cv()`, we recompute the satisfiability vector of the formula to check that it matches what we wanted. This should have a negligible impact on performance but decreases issues due to hash collisions.